### PR TITLE
Fix percent encoded URLs causing the program to crash

### DIFF
--- a/Sources/HexavilleFramework/HexavilleFramework.swift
+++ b/Sources/HexavilleFramework/HexavilleFramework.swift
@@ -41,10 +41,15 @@ extension HexavilleFramework {
             var splited = $0.components(separatedBy: "=")
             headers.add(name: splited.removeFirst(), value: splited.joined(separator: "="))
         }
-        
+
+        // Percent encode URL since API Gateway Lambda Proxy Integration decodes
+        // the strings and the URL will be considered invalid without encoding
+        let encodedPath = path.trimLeft(["/"]).addingPercentEncoding(
+            withAllowedCharacters: .urlQueryAllowed
+        )!
         let request = Request(
             method: HTTPMethod(rawValue: method),
-            url: path == "/" ? URL(string: "aws://api-gateway/")! :  URL(string: "aws://api-gateway/\(path.trimLeft(["/"]))")!,
+            url: path == "/" ? URL(string: "aws://api-gateway/")! :  URL(string: "aws://api-gateway/\(encodedPath)")!,
             headers: headers,
             body: .buffer(body?.data ?? Data())
         )

--- a/Tests/HexavilleFrameworkTests/HexavilleFrameworkTests.swift
+++ b/Tests/HexavilleFrameworkTests/HexavilleFrameworkTests.swift
@@ -1,0 +1,41 @@
+//
+//  HexavilleFrameworkTests.swift
+//  HexavilleFrameworkPackageDescription
+//
+//  Created by Oliver ONeill on 15/9/18.
+//
+
+import Foundation
+import XCTest
+@testable import HexavilleFramework
+
+class HexavilleFrameworkTests: XCTestCase {
+    func testDispatchPercentEncodedRequests() {
+        // Test path with invalid URL characters { and }
+        let path = "/?test={encoded}"
+        let app = HexavilleFramework()
+        var router = Router()
+        // Handles / path
+        router.use(.get, "/") { request, context in
+            XCTAssertEqual("/", request.path)
+            // The query items are intact
+            XCTAssertEqual(
+                [URLQueryItem(name: "test", value: "{encoded}")],
+                request.queryItems
+            )
+            return Response(body: "")
+        }
+        app.use(router)
+        // Dispatch with path
+        _ = app.dispatch(
+            method: "GET",
+            path: path,
+            header: "",
+            body: nil
+        )
+    }
+
+    static var allTests = [
+        ("testDispatchPercentEncodedRequests", testDispatchPercentEncodedRequests),
+    ]
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -3,5 +3,6 @@ import XCTest
 
 XCTMain([
     testCase(RouterTests.allTests),
-    testCase(HostResolverTests.allTests)
+    testCase(HostResolverTests.allTests),
+    testCase(HexavilleFrameworkTests.allTests),
 ])


### PR DESCRIPTION
I specifically had an issue where a request of "/?test={encoded}" due to `{` being an invalid URL character. AWS Lambda Proxy Integration automatically decodes percent encodings and these needs to be re-encoded before creating the request. I've added a test for this specific case, it will crash without my change.