### PR TITLE
Fix failing post requests using local server

### DIFF
--- a/Sources/HexavilleFramework/Core/HTTP/HTTPServer.swift
+++ b/Sources/HexavilleFramework/Core/HTTP/HTTPServer.swift
@@ -77,8 +77,8 @@ private final class HTTPHandler: ChannelInboundHandler {
             self.infoSavedBodyBytes = 0
             self.state.requestReceived()
         case .body(var body):
-            bodyBuffer.writeBuffer(&body)
             infoSavedBodyBytes += body.readableBytes
+            bodyBuffer.writeBuffer(&body)
         case .end:
             self.state.requestComplete()
             let body = bodyBuffer.getData(at: 0, length: infoSavedBodyBytes)


### PR DESCRIPTION
Post requests on local server are failing with response:

dataCorrupted(Swift.DecodingError.Context(codingPath: [], debugDescription: "The given data was not valid JSON.", underlyingError: Optional(Error Domain=NSCocoaErrorDomain Code=3840 "No value." UserInfo={NSDebugDescription=No value.
})))

This is due to the body being empty, writeBuffer(&body) is setting readableBytes to 0, so infoSavedBodyBytes does not correctly increment. Reordering these steps resolves the issue.